### PR TITLE
Added a get method to index

### DIFF
--- a/jquery.indexeddb.js
+++ b/jquery.indexeddb.js
@@ -242,6 +242,12 @@
 									return idbIndex.openKeyCursor(wrap.range(range));
 								}
 							}, callback);
+						},
+						"get": function(key){
+							console.log(idbIndex);
+							return wrap.request(
+								idbIndex.get(key)
+							);
 						}
 					};
 				}
@@ -564,6 +570,9 @@
 							},
 							"eachKey": function(callback, range, direction){
 								return indexOp("eachKey", indexName, [callback, range, direction]);
+							},
+							"get": function(key) {
+								return indexOp("get", indexName, [key]);
 							}
 						};
 					}


### PR DESCRIPTION
An index allows to get objects from the database using the indexed value as key, so I've added this capability to jQuery-IndexedDB.  

Syntax:

``` javascript
$.indexedDB(database)
    .objectStorage(storage)
    .index(index)
    .get(indexedValue)
    .then(onSuccess, onError);
```
